### PR TITLE
fixed two minor bugs

### DIFF
--- a/databallpy/load_data/event_data/opta.py
+++ b/databallpy/load_data/event_data/opta.py
@@ -496,9 +496,12 @@ def _load_event_data(
             result_dict["outcome"].append(MISSING_INT)
         result_dict["start_x"].append(float(event.attrs["x"]))
         result_dict["start_y"].append(float(event.attrs["y"]))
-        result_dict["datetime"].append(
-            pd.to_datetime(event.attrs["timestamp"], utc=True)
+        datetime = (
+            pd.to_datetime(event.attrs["timestamp_utc"], utc=True)
+            if event.attrs["timestamp_utc"]
+            else pd.to_datetime(event.attrs["timestamp"], utc=True)
         )
+        result_dict["datetime"].append(datetime)
 
         # get extra information for databallpy events
 

--- a/databallpy/load_data/event_data/scisports.py
+++ b/databallpy/load_data/event_data/scisports.py
@@ -965,6 +965,15 @@ def _handle_scisports_data(
                     "team_id"
                 ].replace({event_away_team_id: tracking_away_team_id})
 
+            if str(scisports_event_data["team_id"].dtype) == "float64":
+                scisports_event_data["team_id"] = scisports_event_data[
+                    "team_id"
+                ].astype("int64")
+            if str(scisports_event_data["player_id"].dtype) == "float64":
+                scisports_event_data["player_id"] = scisports_event_data[
+                    "player_id"
+                ].astype("int64")
+
         if tracking_data["ball_possession"].isnull().all():
             tracking_data = _add_team_possessions_to_tracking_data(
                 tracking_data,


### PR DESCRIPTION
dtypes in scisports, team_id and player_id converted from floats to ints
use `timestamp_utc` in opta parser if available, otherwise use `timestamp` and assume it is utc (for older data)