### PR TITLE
Fixed minor bug

### DIFF
--- a/databallpy/load_data/event_data/opta.py
+++ b/databallpy/load_data/event_data/opta.py
@@ -496,9 +496,10 @@ def _load_event_data(
             result_dict["outcome"].append(MISSING_INT)
         result_dict["start_x"].append(float(event.attrs["x"]))
         result_dict["start_y"].append(float(event.attrs["y"]))
+
         datetime = (
             pd.to_datetime(event.attrs["timestamp_utc"], utc=True)
-            if event.attrs["timestamp_utc"]
+            if "timestamp_utc" in event.attrs.keys()
             else pd.to_datetime(event.attrs["timestamp"], utc=True)
         )
         result_dict["datetime"].append(datetime)

--- a/databallpy/match.py
+++ b/databallpy/match.py
@@ -220,7 +220,7 @@ class Match:
                 not self.is_synchronised
                 and self.allow_synchronise_tracking_and_event_data
             ):
-                self.synchronise_tracking_and_event_data()
+                self.synchronise_tracking_and_event_data(verbose=False)
             if self.is_synchronised:
                 self.add_tracking_data_features_to_shots()
             res_dict = {


### PR DESCRIPTION
- in opta, attribute "timestamp_utc" was called even when it was not available (earlier versions) which would raise an error.
- In Match, if calling `shots_df` and `synchronise_tracking_and_event_data` needs to be ran, verbose is set to `False`